### PR TITLE
サーバー作成・削除関数の作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@
 
 # Go workspace file
 go.work
+
+# MacOS
+.DS_Store
+

--- a/dathost.go
+++ b/dathost.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
 const baseURL = "https://dathost.net/api/0.1"
@@ -15,24 +16,44 @@ type dathostClientv01 struct {
 }
 
 // ListGameServers implements DatHostClientv01.
-func (dc *dathostClientv01) ListGameServers() {
+func (dc *dathostClientv01) ListGameServers() (string, error) {
 	ep := baseURL + "/game-servers"
-	body, err := dc.sendRequest("GET", ep, nil)
+	body, err := dc.sendRequest("GET", ep, nil, "application/json")
 	if err != nil {
 		fmt.Println(err)
-		return
+		return "", err
 	}
-	fmt.Println(string(body))
+	return string(body), nil
+}
+
+func (dc *dathostClientv01) CreateGameServer(serverName string, cs2token string) (string, error) {
+	ep := baseURL + "/game-servers"
+	// https://dathost.readme.io/reference/post_game_servers
+	payload := strings.NewReader("-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"game\"\r\n\r\ncs2\r\n-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"name\"\r\n\r\n" + serverName + "\r\n-----011000010111000001101001\r\nContent-Disposition: form-data; name=\"csgo_settings.steam_game_server_login_token\"\r\n\r\n" + cs2token + "\r\n-----011000010111000001101001--")
+	body, err := dc.sendRequest("POST", ep, payload, "multipart/form-data")
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+func (dc *dathostClientv01) DeleteGameServer(serverId string) (string, error) {
+	ep := baseURL + "/game-servers/" + serverId
+	body, err := dc.sendRequest("DELETE", ep, nil, "application/json")
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
 }
 
 // sendRequest sends an HTTP request to the given endpoint with the specified method and body.
-func (dc *dathostClientv01) sendRequest(method, endpoint string, body io.Reader) ([]byte, error) {
+func (dc *dathostClientv01) sendRequest(method, endpoint string, body io.Reader, acceptType string) ([]byte, error) {
 	req, err := http.NewRequest(method, endpoint, body)
 	if err != nil {
 		return nil, err
 	}
 
-	req.Header.Add("accept", "application/json")
+	req.Header.Add("accept", acceptType)
 	req.Header.Add("Authorization", dc.auth)
 
 	res, err := http.DefaultClient.Do(req)
@@ -53,5 +74,7 @@ func NewDathostClientv01(username, password string) DatHostClientv01 {
 
 // DatHostClientv01 Client API v0.1
 type DatHostClientv01 interface {
-	ListGameServers() // WIP: types
+	ListGameServers() (string, error)
+	CreateGameServer(serverName string, cs2token string) (string, error)
+	DeleteGameServer(serverId string) (string, error)
 }

--- a/dathost.go
+++ b/dathost.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 )
 
+const baseURL = "https://dathost.net/api/0.1"
+
 // dathostClientv01 Client API v0.1
 type dathostClientv01 struct {
 	auth string // Basic auth with Base64-encoded username/password pair
@@ -14,11 +16,20 @@ type dathostClientv01 struct {
 
 // ListGameServers implements DatHostClientv01.
 func (dc *dathostClientv01) ListGameServers() {
-	ep := "https://dathost.net/api/0.1/game-servers"
-	req, err := http.NewRequest("GET", ep, nil)
+	ep := baseURL + "/game-servers"
+	body, err := dc.sendRequest("GET", ep, nil)
 	if err != nil {
 		fmt.Println(err)
 		return
+	}
+	fmt.Println(string(body))
+}
+
+// sendRequest sends an HTTP request to the given endpoint with the specified method and body.
+func (dc *dathostClientv01) sendRequest(method, endpoint string, body io.Reader) ([]byte, error) {
+	req, err := http.NewRequest(method, endpoint, body)
+	if err != nil {
+		return nil, err
 	}
 
 	req.Header.Add("accept", "application/json")
@@ -26,16 +37,13 @@ func (dc *dathostClientv01) ListGameServers() {
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
-		fmt.Println(err)
-		return
+		return nil, err
 	}
 	defer res.Body.Close()
-	body, _ := io.ReadAll(res.Body)
-
-	fmt.Println(string(body))
-
+	return io.ReadAll(res.Body)
 }
 
+// NewDathostClientv01 creates a new instance of DatHostClientv01.
 func NewDathostClientv01(username, password string) DatHostClientv01 {
 	base64Auth := base64.StdEncoding.EncodeToString([]byte(username + ":" + password))
 	return &dathostClientv01{

--- a/examples/create_gameserver/main.go
+++ b/examples/create_gameserver/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/FlowingSPDG/dathost-go"
+)
+
+func main() {
+	client := dathost.NewDathostClientv01("", "")
+
+	const cs2token = "YOUR_STEAM_GAMESERVER_TOKEN"
+	const serverName = "testserver"
+	res, err := client.CreateGameServer(serverName, cs2token)
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(res)
+}

--- a/examples/delete_gameserver/main.go
+++ b/examples/delete_gameserver/main.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/FlowingSPDG/dathost-go"
+)
+
+func main() {
+	client := dathost.NewDathostClientv01("", "")
+
+	const serverId = "1234567890"
+	res, err := client.DeleteGameServer(serverId)
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(res)
+}


### PR DESCRIPTION
### 変更の概要
サーバー作成・削除関数の作成
リクエストを送るための関数の作成

### 利用方法
利用方法はexampleフォルダ直下の create_gameserver / delete_gameserverをご覧ください。
普段Go言語はあまり触らないため、将来的なリファクタリングが必須かと思います。

### 関数一覧
`CreateGameServer(serverName string, cs2token string) -> string`
`DeleteGameServer(serverId string) -> string`
`sendRequest(method, endpoint string, body io.Reader, acceptType string) -> byte[]`
CreateGameServer関数に関しては帰ってくるstringオブジェクトに対してパースする必要はないかと思っているため、
そのまま返しています。


※元々dathostで管理するために自分用に作成したため、要らなければPRクローズしてください。

